### PR TITLE
Update PyPI domain

### DIFF
--- a/src/minimum_dependencies/_core.py
+++ b/src/minimum_dependencies/_core.py
@@ -38,7 +38,7 @@ def versions(requirement: Requirement) -> list[Version]:
     A sorted list of versions available on PyPi for the given requirement.
     """
     content = requests.get(
-        f"https://pypi.python.org/pypi/{requirement.name}/json",
+        f"https://pypi.org/pypi/{requirement.name}/json",
         timeout=30,
     ).json()
 

--- a/src/minimum_dependencies/tests/test_core.py
+++ b/src/minimum_dependencies/tests/test_core.py
@@ -50,7 +50,7 @@ class TestVersions:
         requirement = Requirement("poppy>=1.0.2")
         num_releases = len(
             requests.get(
-                f"https://pypi.python.org/pypi/{requirement.name}/json",
+                f"https://pypi.org/pypi/{requirement.name}/json",
                 timeout=30,
             ).json()["releases"],
         )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist= py38,py39,py310,py311
+envlist= py39,py310,py311,py312
 isolated_build= True
 
 [testenv]


### PR DESCRIPTION
Back in 2017 PyPI was rewritten to use https://pypi.org 
Refs: https://mail.python.org/pipermail/distutils-sig/2017-June/030766.html

Redirects were put into place to support gradual migration, but the recommendation is to update to use pypi.org instead. 
https://warehouse.pypa.io/api-reference/integration-guide.html#migrating-to-the-new-pypi

Removes a redirect-per-request.